### PR TITLE
Enable CUDA Makefile

### DIFF
--- a/cgotorch/Makefile.linux-gpu
+++ b/cgotorch/Makefile.linux-gpu
@@ -1,0 +1,27 @@
+all : libcgotorch.so
+
+libtorch-cxx11-1.6.0-linux-cuda102.zip :
+	curl -Lso libtorch-cxx11-1.6.0-linux-cuda102.zip 'https://download.pytorch.org/libtorch/cu102/libtorch-cxx11-abi-shared-with-deps-1.6.0.zip'
+
+linux-gpu/libtorch : libtorch-cxx11-1.6.0-linux-cuda102.zip
+	unzip -qq -o $< -d linux-gpu
+
+libcgotorch.so : torch.cc functional.cc init.cc optim.cc cgotorch.h linux-gpu/libtorch
+	rm -f libtorch
+	ln -s linux-gpu/libtorch libtorch
+	clang++ -std=c++14 \
+	-I .. \
+	-I libtorch/include \
+	-I libtorch/include/torch/csrc/api/include \
+	-L libtorch/lib \
+	-fPIC \
+	-shared \
+	torch.cc functional.cc init.cc optim.cc \
+	-o $@ \
+	-Wl,-rpath,libtorch/lib \
+	-Wl,-force_load libtorch/lib/libc10.so \
+	-lc10 -ltorch -ltorch_cpu \
+	-D_GLIBCXX_USE_CXX11_ABI=1
+
+clean:
+	rm -rf *.so

--- a/device_test.go
+++ b/device_test.go
@@ -1,6 +1,7 @@
 package gotorch_test
 
 import (
+	"log"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,8 +12,10 @@ func TestDevice(t *testing.T) {
 	a := assert.New(t)
 	var device torch.Device
 	if torch.IsCUDAAvailable() {
+		log.Println("CUDA is valid")
 		device = torch.NewDevice("cuda")
 	} else {
+		log.Println("No CUDA found; CPU only")
 		device = torch.NewDevice("cpu")
 	}
 	a.NotNil(device)

--- a/mnist_test.go
+++ b/mnist_test.go
@@ -47,7 +47,7 @@ func ExampleTrainMNIST() {
 	opt := torch.SGD(0.01, 0.5, 0, 0, false)
 	opt.AddParameters(net.Parameters())
 
-	epochs := 5
+	epochs := 2
 	startTime := time.Now()
 	var lastLoss float32
 	for epoch := 0; epoch < epochs; epoch++ {


### PR DESCRIPTION
On my Ubuntu 18.04 workstation with TitanX GPU and CUDA 11 installed, I can run the following command to build the CUDA-enabled version of `cgotroch`:

```
cd cgotorch
make -f Makefile.linux-gpu
```

The above command will download libtorch for CUDA 10.2 from the official Web site if not yet.

Then, when I ran the Go tests, the `device_test.go` file prints a log message showing it noticed the existence of my GPU and created the tensor on GPU.

```
yi@bigb:~/go/src/github.com/wangkuiyi/gotorch (gpu)*$ gotest -v
=== RUN   TestPanicMNIST
--- PASS: TestPanicMNIST (0.00s)
=== RUN   TestDevice
2020/08/13 16:38:11 CUDA is valid
```